### PR TITLE
Reintroduce "empty" template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Template for creating new `clemgames'
 
-This repository provides example code for starting to develop new games for the `clemcore' environment, as used in the `clembench' project.
+This repository provides example code for starting to develop new games for the `clemcore` environment, as used in the `clembench` project.
 
 [documentation to be further adapted]
 

--- a/empty_template/clemgame.json
+++ b/empty_template/clemgame.json
@@ -1,0 +1,9 @@
+{
+  "game_name": "some_game",
+  "description": "There might be a game here in the future.",
+  "main_game": "some_game",
+  "players": "one",
+  "image": "none",
+  "languages": ["en"],
+  "benchmark": []
+}

--- a/empty_template/instancegenerator.py
+++ b/empty_template/instancegenerator.py
@@ -1,0 +1,35 @@
+"""Template script for instance generation.
+
+usage:
+python3 instancegenerator.py
+Creates instance.json file in ./in
+
+"""
+import json
+import os
+import random
+import logging
+import openai
+import requests
+import spacy
+import argparse
+
+from clemcore.clemgame import GameInstanceGenerator
+
+logger = logging.getLogger(__name__)
+
+
+N_INSTANCES = 20
+# Seed for reproducibility
+random.seed(73128361)
+
+class SomeGameInstanceGenerator(GameInstanceGenerator):
+    def __init__(self):
+        super().__init__(os.path.dirname(__file__))
+
+    def on_generate(self):
+        pass
+
+
+if __name__ == '__main__':
+    SomeGameInstanceGenerator().generate()

--- a/empty_template/instancegenerator.py
+++ b/empty_template/instancegenerator.py
@@ -5,19 +5,13 @@ python3 instancegenerator.py
 Creates instance.json file in ./in
 
 """
-import json
 import os
 import random
 import logging
-import openai
-import requests
-import spacy
-import argparse
 
 from clemcore.clemgame import GameInstanceGenerator
-
+# Initialize logging
 logger = logging.getLogger(__name__)
-
 
 N_INSTANCES = 20
 # Seed for reproducibility

--- a/empty_template/master.py
+++ b/empty_template/master.py
@@ -82,7 +82,6 @@ class SomeGameScorer(GameScorer):
                 self.log_round_score(round_idx,'response_received', 1)
 
     def compute_episode_scores(self, interactions: Dict):
-        # TODO: check how to properly record/access benchscore now
         if interactions[METRIC_SUCCESS]:
             self.log_episode_score(BENCH_SCORE, 100)
         elif interactions[METRIC_LOSE]:

--- a/empty_template/master.py
+++ b/empty_template/master.py
@@ -1,0 +1,105 @@
+from typing import Dict, Tuple, List, Union
+import logging
+import numpy as np
+
+from clemcore.backends import Model
+from clemcore.clemgame import GameSpec, GameBenchmark, GameMaster, Player, DialogueGameMaster, GameScorer, \
+    GameError, ParseError, RuleViolationError
+from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_SUCCESS, METRIC_LOSE, BENCH_SCORE
+
+logger = logging.getLogger(__name__)
+
+
+class SomeGamePlayer(Player):
+    def __init__(self, model: Model):
+        super().__init__(model)
+        self._custom_responses = ["Apple", "Banana", "Cherry"]
+
+    def _custom_response(self, messages):
+        word = self._custom_responses.pop(0)
+        return f'{word}'
+
+
+class SomeGameMaster(DialogueGameMaster):
+    """
+    Template class for game master.
+    """
+    def __init__(self, game_spec: GameSpec, experiment: Dict, player_models: List[Model]):
+        super().__init__(game_spec, experiment, player_models)
+
+    def _on_setup(self, **game_instance):
+        self.game_instance = game_instance
+
+        self.some_player = SomeGamePlayer(self.player_models[0])
+
+        self.add_player(self.some_player, initial_context=game_instance['initial_prompt'])
+
+        self.success = False
+
+    def _advance_game(self, player: Player, parsed_response: str):
+        if not parsed_response:
+            raise RuleViolationError
+        self.success = True
+        self.log_to_self('player_response', parsed_response)
+
+    def _parse_response(self, player: Player, response: str) -> str:
+        if response:
+            return response
+        else:
+            raise ParseError
+
+    def _on_parse_error(self, error: GameError):
+        self.success = False
+
+    def _does_game_proceed(self):
+        """
+        Proceed anyways. This should check for anything that ends an episode.
+        """
+        return True
+
+    def compute_turn_score(self):
+        return 1 if self.success else 0
+
+    def compute_episode_score(self):
+        if self.success:
+            return 100 / (self.current_round + 1)  # zero-based
+        return 0
+
+    def _on_after_game(self):
+        if self.success:
+            self.log_key(METRIC_SUCCESS, True)
+        else:
+            self.log_key(METRIC_SUCCESS, False)
+
+
+class SomeGameScorer(GameScorer):
+    def __init__(self, game_name: str, experiment: Dict, game_instance: Dict):
+        super().__init__(game_name, experiment, game_instance)
+
+    def compute_round_score(self, round_idx, round_events: List[Dict]) -> None:
+        for event in round_events:
+            if event["action"]["type"] == "player_response":
+                self.log_round_score(round_idx,'response_received', 1)
+
+    def compute_episode_scores(self, interactions: Dict):
+        # TODO: check how to properly record/access benchscore now
+        if interactions[METRIC_SUCCESS]:
+            self.log_episode_score(BENCH_SCORE, 100)
+        elif interactions[METRIC_LOSE]:
+            self.log_episode_score(BENCH_SCORE, 0)
+        elif interactions[METRIC_ABORTED]:
+            self.log_episode_score(BENCH_SCORE, np.nan)
+        else:
+            raise ValueError("Missing outcome value (success, failure, abort) in interactions.json")
+
+
+class SomeGameBenchmark(GameBenchmark):
+
+    def __init__(self, game_spec: GameSpec):
+        super().__init__(game_spec)
+
+    def create_game_master(self, experiment: Dict, player_models: List[Model]) -> GameMaster:
+        return SomeGameMaster(self.game_spec, self.game_path, experiment, player_models)
+
+    def create_game_scorer(self, experiment: Dict, game_instance: Dict) -> GameScorer:
+        return SomeGameScorer(self.game_name, experiment, game_instance)

--- a/empty_template/resources/initial_prompts/initial_prompt.template
+++ b/empty_template/resources/initial_prompts/initial_prompt.template
@@ -1,0 +1,1 @@
+You are playing a game!

--- a/key.json.template
+++ b/key.json.template
@@ -5,5 +5,6 @@
   "cohere": {"api_key": ""},
   "mistral": {"api_key": ""},
   "huggingface": {"api_key": "", "organisation": ""},
-  "generic_openai_compatible": {"api_key":"", "base_url": ""}
+  "generic_openai_compatible": {"api_key":"", "base_url": ""},
+  "openrouter": {"api_key": ""}
 }


### PR DESCRIPTION
The How To Make A Clemgame tutorial notebook on the clemcore repository relies on the "empty" template for ease of learning the core aspects needed to implement a new clemgame, without the extra burden of learning the clemcore codebase. Thus the minimal placeholder implementation is not replacable with an entire example implementation like the existing Taboo example.